### PR TITLE
Fixes encoding errors thrown from Python

### DIFF
--- a/dongerdong.py
+++ b/dongerdong.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+# -*- coding: utf-8
 import pydle
 import json
 import logging


### PR DESCRIPTION
Python can throw an error such as:

>   File "dongerdong.py", line 293
> SyntaxError: Non-ASCII character '\xe3' in file dongerdong.py on line 293, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details

This one liner fixes that.
