### PR TITLE
Removes dong from top list

### DIFF
--- a/dongerdong.py
+++ b/dongerdong.py
@@ -256,6 +256,8 @@ class Donger(BaseClient):
                     for player in players:
                         if (player.fights + player.accepts + player.joins) < 5:
                             continue
+                        if (player.nick == config['nick']):
+                            continue
                         try:
                             p[player.nick] = round((player.wins - player.losses) + (player.fights * config['topmodifier']))
                         except KeyError:


### PR DESCRIPTION
Removes dong (config[nick]) from the !top command. Stats should keep tracking tho.

Side note:
The exclusion checks for stat counting for dong should be refactored in to the countStat() method or removed altogether. I didn't feel like doing that, though.